### PR TITLE
Correct the gem name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can also block certain usernames from creating accounts. Examples: admin, ro
 ## Installation
 Add this line to your application's Gemfile:
 ```ruby
-gem "check_email"
+gem "email_check"
 ```
 
 ## Usage


### PR DESCRIPTION
Small fix: When I tried installing the gem, `check_email` did not work, and then I realized that the gem name in the `README` should say `email_check`.