### PR TITLE
Handle nil domain in email when checking blacklist

### DIFF
--- a/lib/email_check/email_address.rb
+++ b/lib/email_check/email_address.rb
@@ -23,7 +23,7 @@ module EmailCheck
 
     def blacklisted_domain?
       EmailCheck.blacklisted_domains.each do |domain|
-        return true if @email.domain.include?(domain)
+        return true if @email.domain&.include?(domain)
       end
 
       false

--- a/spec/email_check_spec.rb
+++ b/spec/email_check_spec.rb
@@ -114,7 +114,7 @@ describe EmailCheck do
       expect(TestBlacklistedEmail.new(email:"user@sub.gmail.com").valid?).to be false
     end
 
-    it "should not be valid when there is no domain" do
+    it "should not be blacklisted when there is no domain on an email address" do
       EmailCheck.blacklisted_domains << "gmail.com"
       email = "someone"
       email_address = EmailCheck::EmailAddress.new(email)

--- a/spec/email_check_spec.rb
+++ b/spec/email_check_spec.rb
@@ -113,6 +113,13 @@ describe EmailCheck do
       expect(TestBlacklistedEmail.new(email:"user@gmail.com").valid?).to be false
       expect(TestBlacklistedEmail.new(email:"user@sub.gmail.com").valid?).to be false
     end
+
+    it "should not be valid when there is no domain" do
+      EmailCheck.blacklisted_domains << "gmail.com"
+      email = "someone"
+      email_address = EmailCheck::EmailAddress.new(email)
+      expect(email_address.blacklisted_domain?).to be false
+    end
   end
 
   describe "Whitelisted Emails" do


### PR DESCRIPTION
We encountered an exception when checking local (or malformed) email addresses against the domain blacklist. This is a simple pull to avoid the exception by not checking nil domains.