### PR TITLE
Added more popular disposable domains

### DIFF
--- a/vendor/disposable.yml
+++ b/vendor/disposable.yml
@@ -8,6 +8,7 @@
 - 10minutemail.co.za
 - 10minutemail.com
 - 10minutemail.de
+- 10minutesemail.net
 - 123-m.com
 - 1chuan.com
 - 1fsdfdsfsdf.tk
@@ -45,6 +46,7 @@
 - a-bc.net
 - a45.in
 - abcmail.email
+- about27.com
 - acentri.com
 - advantimo.com
 - afrobacon.com
@@ -106,6 +108,8 @@
 - buymoreplays.com
 - buyusedlibrarybooks.org
 - byom.de
+- bvhrk.com
+- bvhrs.com
 - c2.hu
 - cachedot.net
 - card.zp.ua
@@ -194,10 +198,12 @@
 - e-mail.org
 - e4ward.com
 - easytrashmail.com
+- edu.email.edu.pl
 - einmalmail.de
 - einrot.com
 - einrot.de
 - eintagsmail.de
+- email.edu.pl
 - email60.com
 - emaildienst.de
 - emailgo.de
@@ -363,11 +369,14 @@
 - ip6.li
 - ipoo.org
 - irish2me.com
+- ironflys.com
 - iwi.net
+- jeoce.com
 - jetable.com
 - jetable.fr.nf
 - jetable.net
 - jetable.org
+- jiooq.com
 - jnxjn.com
 - jourrapide.com
 - jsrsolutions.com
@@ -387,6 +396,9 @@
 - koszmail.pl
 - kulturbetrieb.info
 - kurzepost.de
+- kvhrr.com
+- kvhrs.com
+- kvhrw.com
 - l33r.eu
 - lackmail.net
 - lags.us
@@ -398,6 +410,7 @@
 - link2mail.net
 - litedrop.com
 - loadby.us
+- lockaya.com
 - login-email.ml
 - lol.ovpn.to
 - lolfreak.net
@@ -536,6 +549,7 @@
 - netzidiot.de
 - neverbox.com
 - nice-4u.com
+- nifect.com
 - nincsmail.hu
 - nnh.com
 - no-spam.ws
@@ -559,6 +573,8 @@
 - notsharingmy.info
 - nowhere.org
 - nowmymail.com
+- nthrl.com
+- nthrw.com
 - nurfuerspam.de
 - nus.edu.sg
 - nwldx.com
@@ -620,6 +636,7 @@
 - royal.net
 - rppkn.com
 - rtrtr.com
+- runchet.com
 - s0ny.net
 - safe-mail.net
 - safersignup.de
@@ -627,6 +644,7 @@
 - safetypost.de
 - sandelf.de
 - saynotospams.com
+- sceath.com
 - schafmail.de
 - schrott-email.de
 - secretemail.de
@@ -649,6 +667,7 @@
 - showslow.de
 - sibmail.com
 - sinnlos-mail.de
+- sinyago.com
 - siteposter.net
 - skeefmail.com
 - slapsfromlastnight.com
@@ -731,6 +750,7 @@
 - squizzy.de
 - ssoia.com
 - startkeys.com
+- steamoh.com
 - stinkefinger.net
 - stop-my-spam.com
 - stuffmail.de
@@ -818,6 +838,7 @@
 - trialmail.de
 - trillianpro.com
 - tryalert.com
+- tsclip.com
 - turual.com
 - twinmail.de
 - twoweirdtricks.com
@@ -880,6 +901,7 @@
 - wwwnew.eu
 - x.ip6.li
 - xagloo.com
+- xcoxc.com
 - xemaps.com
 - xents.com
 - xmaily.com
@@ -897,6 +919,7 @@
 - yuurok.com
 - z1p.biz
 - za.com
+- zcrcd.com
 - zehnminuten.de
 - zehnminutenmail.de
 - zetmail.com


### PR DESCRIPTION
Hi there! First of all, thanks for the great gem!

I've found a couple more of popular disposable email domains and it would be nice to add them to the list:

10minutemail.net

- xcoxc.com
- jiooq.com
- jeoce.com
- zcrcd.com

temp-mail.org

- tsclip.com
- runchet.com
- sceath.com
- about27.com
- nifect.com
- lockaya.com
- steamoh.com
- sinyago.com

10minutemail.com

- kvhrs.com
- kvhrr.com
- kvhrw.com
- bvhrs.com
- bvhrk.com
- nthrl.com
- nthrw.com

minuteinbox.com

- ironflys.com

10minutesemail.net

- 10minutesemail.net
- email.edu.pl
- edu.email.edu.pl